### PR TITLE
Fix example solver encoding issues on windows

### DIFF
--- a/ratkaisin.py
+++ b/ratkaisin.py
@@ -17,7 +17,7 @@ try:
     status = input()
     while status:
         for letter, frequency in guess_order:
-            print(letter)
+            print(letter.encode('utf8'))
             result = input()
             status = input()
             if status.startswith('WIN') or status.startswith('LOSE') or not status:


### PR DESCRIPTION
Esimerkki ratkaisin ei toiminut windowsilla koska se lähetti ääkkösiä väärällä enkoodauksella